### PR TITLE
Bootstrap Python packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include *.md
+include LICENSE
+recursive-include tests *.py
+
+exclude make-test-chroot
+exclude run_coverage
+exclude run_type_checker
+exclude update_docs

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,39 @@
+import pathlib
+
+from setuptools import find_packages, setup
+
+here = pathlib.Path(__file__).parent.resolve()
+long_description = (here / "README.md").read_text(encoding="utf-8")
+
+setup(
+    name="transilience",
+    version="0.1.0.dev0",
+    description="A provisioning library",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/spanezz/transilience/",
+    author="Enrico Zini",
+    author_email="enrico@enricozini.org",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
+        "Topic :: System :: Systems Administration",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3 :: Only",
+    ],
+    packages=find_packages(where="."),
+    python_requires=">=3.7, <4",
+    install_requires=[
+        # "coloredlogs", # Optional
+        "jinja2",
+        "mitogen",
+    ],
+    extras_require={
+        "device": ["parted"],
+    },
+)


### PR DESCRIPTION
We add a setup.py with basic metadata and dependencies. Only "jinja2"
and "mitogen" dependencies are required. Other ones appear to be
optional: "import coloredlogs" is handled, and "parted" is only required
for the "device" module which is apparently not imported internally (the
dependency is thus defined as an "extra").

A MANIFEST.in file is also added to configure sdist. We exclude
developer scripts, probably not useful to distribute as is.