### PR TITLE
Fix package name for 'yaml' module in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         # "yapf", # Optional
         "jinja2",
         "mitogen",
-        "yaml",
+        "PyYAML",
     ],
     extras_require={
         "device": ["parted"],


### PR DESCRIPTION
The package name is PyYAML, as registered in PyPI.